### PR TITLE
passing arguments to quick_start.py file instead of changing company …

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ To try out the package, follow the steps below:
 * `chmod +x setup.sh` to make bash file executable
 * `./setup.sh` to run executable - this installs a virtualenv and downloads relevant data
 * Setup a Bing API on Azure and replace the subscription key in `config.py` (there is a free version)
-* Change the company name in the 'main' function of `quick_start.py`, then run
+* From the command line / terminal, type in:>> python quick_start.py --company_name "<company_name_of_your_choice>" to get the embedding. 
+* For short hand notation type in:>> python quick_start.py -c "<company_name_of_your_choice>" 
 
 ## Features
 

--- a/quick_start.py
+++ b/quick_start.py
@@ -1,6 +1,7 @@
 """This module provides a quick way to start using company2vec"""
 
 import json
+import argparse
 
 from app.urls import URLFinder
 from app.pipelines import Pipeline, return_company_embedding
@@ -37,7 +38,12 @@ def run_single(company_name):
 
 if __name__ == '__main__':
 
-    company = 'bbc'
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-c", "--company_name", required=True, help="pass on the company name of your choice")
+    args = vars(ap.parse_args())
+
+    company = args["company_name"]
+    print("Company passed: ", company)
     embedding = run_single(company)
     print(embedding)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argparse
 scrapy
 numpy
 requests


### PR DESCRIPTION
passing arguments to quick_start.py file instead of changing company name in script each time. This save time.

Command to be used:

python quick_start.py -c "<company_name_of_your_choice>" ## short hand notation
 (or)
python quick_start.py --company_name "<company_name_of_your_choice>" ## detailed notation

Made changes to requirements.txt, Readme.md and quick_start.py